### PR TITLE
exclude goto statements and labels from accounting

### DIFF
--- a/src/luacov/linescanner.lua
+++ b/src/luacov/linescanner.lua
@@ -79,7 +79,9 @@ local zero_hits_exclusions = {
    "break", -- "break" generates no trace in Lua 5.2+
    "{", -- "{" opening table
    "}?[ %)]*", -- optional closing paren, possibly with several closing parens
-   "[ntf0']+ ?}[ %)]*" -- a constant at the end of a table, possibly with closing parens (for LuaJIT)
+   "[ntf0']+ ?}[ %)]*", -- a constant at the end of a table, possibly with closing parens (for LuaJIT)
+   "goto [%w_]+", -- goto statements
+   "::[%w_]+::", -- labels
 }
 
 local function excluded(exclusions, line)


### PR DESCRIPTION
This solves https://github.com/keplerproject/luacov/issues/89 but that bug isn't getting any response, so we'll solve it in our repo.